### PR TITLE
feat: implement logger outside of elysia

### DIFF
--- a/example/index.ts
+++ b/example/index.ts
@@ -1,0 +1,17 @@
+import { Elysia } from 'elysia'
+import { Logger, loggerPlugin } from 'logger.plugin.js'
+
+export const AppLogger = new Logger({ filePath: './logs/app.log' })
+
+const app = new Elysia()
+  .use(
+    loggerPlugin({
+      logLevel: 'info',
+      filePath: './logs/app.log',
+      scope: 'global',
+    })
+  )
+  .get('/', ({ status }) => status(200, { message: 'hello from elysia' }))
+  .listen(3001)
+
+AppLogger.log('info', 'App started')

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "type": "module",
   "main": "index.ts",
   "scripts": {
+    "dev:logger": "bun --watch example/index.ts" ,
     "compile": "tsc",
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
This commit introduces a logger to use outside elysia instance in some cases and an example implementation.

The example implementation demonstrates how to use the logger plugin in an Elysia application. It sets up a basic Elysia server with logging enabled and includes a simple route that logs a message when accessed.

![image](https://github.com/user-attachments/assets/bdaa9789-f01b-4660-a19c-6f122dddb9ee)
